### PR TITLE
Update 鈸 with 咚隆咚隆 and fix a few typos

### DIFF
--- a/pages/01-history.md
+++ b/pages/01-history.md
@@ -7,7 +7,7 @@ background: /DSC09284.jpg
 
 ---
 
-## A bit (🥁鈸) of fundamentals
+## A bit (🥁咚隆咚隆) of fundamentals
 
 <div class="mt-5">
 

--- a/pages/01-history.md
+++ b/pages/01-history.md
@@ -31,7 +31,7 @@ Those structures are inherently computer orientated - not human orientated:
 
 <!--
 
-👆 Although unimportant for this talk, these things are the main language of a computer, bits, bytes, words. Compilers compile our code, so we can make more __human__ structures. Often the compilers optimise our code for thigns the computer understands.
+👆 Although unimportant for this talk, these things are the main language of a computer, bits, bytes, words. Compilers compile our code, so we can make more __human__ structures. Often the compilers optimise our code for things the computer understands.
 
 -->
 
@@ -142,7 +142,7 @@ When we open up to interpretation as with a certain bit sequence meaning "H", th
 
 ## Competing standards
 
-- ~~ANSI (American National Standards Institue) Characters~~ Windows code pages, Code Page 437
+- ~~ANSI (American National Standards Institute) Characters~~ Windows code pages, Code Page 437
 - ASCII (American Standard Code for Information Interchange) Characters
 
 <div v-click class="mt-10">
@@ -155,7 +155,7 @@ When we open up to interpretation as with a certain bit sequence meaning "H", th
 ┃                                                                                     ┃ 
 ┃                    ┏━━━━━━━━━━━━━━━━━━┫ Prompt ┣━━━━━━━━━━━━━━━━┓                   ┃
 ┃                    ┃                                            ┃                   ┃ 
-┃                    ┃ DO YOU WANT YOUR LANGAUGE TO BE SUPPORTED? ┃                   ┃
+┃                    ┃ DO YOU WANT YOUR LANGUAGE TO BE SUPPORTED? ┃                   ┃
 ┃                    ┃                                            ┃                   ┃
 ┃                    ┗━━━━━━━━━━━━━━━━━━┫ No ┣━┫ >Nah not even< ┣━┛                   ┃
 ┃                                                                                     ┃ 
@@ -170,7 +170,7 @@ When we open up to interpretation as with a certain bit sequence meaning "H", th
 </div>
 
 <!--
-ANSI Characters aren't actually a thing. When people use this term, they are refering to the windows code pages.
+ANSI Characters aren't actually a thing. When people use this term, they are referring to the windows code pages.
 
 Quiz: How many bits is an ascii character?
 
@@ -219,7 +219,7 @@ IBM437: https://www.compart.com/en/unicode/charsets/IBM437
 
 ---
 
-## How many characters is enough charcters?
+## How many characters is enough characters?
 
 <p class="pt-5">
 

--- a/pages/01-history.md
+++ b/pages/01-history.md
@@ -25,7 +25,7 @@ Those structures are inherently computer orientated - not human orientated:
 - 8 bits makes a byte
 - 4/8 bytes makes a word on 32/64 bit architectures respectively
   
-  <sup>(last you'll heard of "words" in this presentation)</sup>
+  <sup>(last time you'll heard of "words" in this presentation)</sup>
 
 </v-clicks>
 
@@ -261,6 +261,6 @@ Bits are not human structures - so we abstract
 
 `char` isn't a character, it's just a `uint8_t` with a fancy name
 
-We need a whole lot more bits if we more than just names and dates in europe
+We need a whole lot more bits if we want more than just names and dates in europe
 
 </v-clicks>

--- a/pages/02-unicode.md
+++ b/pages/02-unicode.md
@@ -11,7 +11,7 @@ background: /DSC09097.jpg
 
 <v-clicks>
 
-1. Codepages/charmaps? System dependant
+1. Codepages/charmaps? System dependent
 1. Unique characters? Duplication everywhere
 1. Display more than one codepage/charmap at a time? ␎␏␎␏␎␏␎␏
 1. Text from outside of Europe? :ha:
@@ -58,7 +58,7 @@ layout: center
 
 <!--
 - Universal: Encompass all characters that can be used in general text interchange
-- Efficient: Simple to store and parse. Fixed character codes for all the charaters, no switch code pages/charmaps.
+- Efficient: Simple to store and parse. Fixed character codes for all the characters, no switch code pages/charmaps.
 - Unambiguous: `\1F600` is a grinning face - everywhere.
 
 Ref: https://www.unicode.org/versions/Unicode15.0.0/ch01.pdf
@@ -258,7 +258,7 @@ Key points:
 
 <!--
 UTF-8 is generally speaking more efficient when dealing with "Latin" based web - Best case 1 byte, worst case, 2 bytes.
-UTF-16 is gauranteed to be 2 bytes, if not 4
+UTF-16 is guaranteed to be 2 bytes, if not 4
 UTF-32 will always be 4 bytes.
 -->
 
@@ -395,7 +395,7 @@ layout: center
 
 <v-clicks>
 
-Unicode is a standard. It defeines a dictionary of `codepoints` to their character descriptions
+Unicode is a standard. It defines a dictionary of `codepoints` to their character descriptions
 
 UTF-8 is an Encoding - defined by the Unicode Standard.
 

--- a/pages/03-unicode-in-rust.md
+++ b/pages/03-unicode-in-rust.md
@@ -104,7 +104,7 @@ Therefore string slices are slices of bytes
 layout: center
 ---
 
-## A String slice (`str`) is just a slice of bytes (`[u8]`), **which contents are always valid UTF-8**.
+## A String slice (`str`) is just a slice of bytes (`[u8]`), **whose contents are always valid UTF-8**.
 
 ---
 layout: center

--- a/pages/03-unicode-in-rust.md
+++ b/pages/03-unicode-in-rust.md
@@ -371,12 +371,12 @@ Ref: https://datatracker.ietf.org/doc/html/rfc8259#section-8.1
 <!--
 The execution never completes, and outputs "Hello world", but not the exclamation mark.
 
-unsafe could be burried in dependencies - it shouldn't be, but it could be.
+unsafe could be buried in dependencies - it shouldn't be, but it could be.
 -->
 
 ---
 
-## Conventially UTF-8 vs. Gauranteed
+## Conventially UTF-8 vs. Guaranteed
 
 Sometimes you just want cats:
 
@@ -425,7 +425,7 @@ layout: center
 
 <v-clicks>
 
-`str` is the primitive string - a slice of bytes with gaurantees of UTF-8
+`str` is the primitive string - a slice of bytes with guarantees of UTF-8
 
 `str` is always `UTF-8`
 


### PR DESCRIPTION
Thanks for sharing the deck, learned a lot!
The only thing I noticed a bit wired, as a native Chinese speaker, is the use of `(🥁鈸)` in the beginning of "History".
I'm assuming the intention is to express "the sound of drum for an exciting opening", if so, I'd recommend `咚隆咚隆` instead.

<details><summary>more detail</summary>

![image](https://github.com/b-n/demystifying-unicode/assets/12410942/b558573b-be5f-46a6-b7fd-464eadf5dc66)

</details>

Also fixes a few typos I noticed. Hope this PR helps!